### PR TITLE
fix: search_found_card

### DIFF
--- a/apps/air_quality/lib/features/search/presentation/widget/search_found_card.dart
+++ b/apps/air_quality/lib/features/search/presentation/widget/search_found_card.dart
@@ -38,11 +38,12 @@ class SearchFoundCard extends StatelessWidget {
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
                 Container(
-                  width: 200,
+                  width: 180,
                   child: Text(
                     location,
+                    maxLines: 2,
                     style: const TextStyle(
-                        fontSize: 20,
+                        fontSize: 16,
                         color: Colors.black,
                         fontWeight: FontWeight.normal,
                         decoration: TextDecoration.none),
@@ -55,7 +56,7 @@ class SearchFoundCard extends StatelessWidget {
                     Text('$aqi',
                         style: TextStyle(
                           color: textcolor,
-                          fontSize: 36,
+                          fontSize: 32,
                           fontWeight: FontWeight.w600,
                           decoration: TextDecoration.none,
                           shadows: [


### PR DESCRIPTION
fix : search_found_card
       ปรับขนาดของตำแหน่งที่แสดง( location ) ให้เล็กลง แสดงได้ 2 บรรทัด และปรับความกว้างให้เหมาะสม

<img width="398" alt="Screenshot 2567-05-17 at 19 13 50" src="https://github.com/noontts/flutter-air-quality/assets/118959844/3aa09d5e-434a-41ea-b60f-ed7ed4a6a297">
